### PR TITLE
Check variables naming convention

### DIFF
--- a/src/main/kotlin/org/vlang/ide/inspections/namingConventions/VlangVarNamingConventionInspection.kt
+++ b/src/main/kotlin/org/vlang/ide/inspections/namingConventions/VlangVarNamingConventionInspection.kt
@@ -1,0 +1,17 @@
+package org.vlang.ide.inspections.namingConventions
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.vlang.lang.psi.VlangVarDefinition
+import org.vlang.lang.psi.VlangVisitor
+
+class VlangVarNamingConventionInspection : VlangNamingConventionInspectionBase() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : VlangVisitor() {
+            override fun visitVarDefinition(o: VlangVarDefinition) {
+                super.visitVarDefinition(o)
+                holder.checkSnakeCase(o, "Variable")
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/inspections.xml
+++ b/src/main/resources/META-INF/inspections.xml
@@ -147,6 +147,12 @@
                          implementationClass="org.vlang.ide.inspections.namingConventions.VlangClassLikeNamingConventionInspection"/>
 
         <localInspection language="vlang" groupPath="V"
+                         groupName="Naming conventions" shortName="VlangVarNamingConventionInspection"
+                         displayName="Variable naming convention"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.vlang.ide.inspections.namingConventions.VlangVarNamingConventionInspection"/>
+
+        <localInspection language="vlang" groupPath="V"
                          groupName="Naming conventions" shortName="VlangTypeAliasNamingConventionInspection"
                          displayName="Type alias naming convention"
                          enabledByDefault="true" level="ERROR"

--- a/src/main/resources/inspectionDescriptions/VlangVarNamingConventionInspection.html
+++ b/src/main/resources/inspectionDescriptions/VlangVarNamingConventionInspection.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Reports variables whose names do not follow the naming convention.
+</body>
+</html>

--- a/src/test/kotlin/org/vlang/ide/inspections/VlangNamingConventionsInspectionsTest.kt
+++ b/src/test/kotlin/org/vlang/ide/inspections/VlangNamingConventionsInspectionsTest.kt
@@ -16,6 +16,8 @@ class VlangNamingConventionsInspectionsTest : InspectionTestBase("namingConventi
     fun `test generic receivers names`() = doTest("generic_receivers_names.v", VlangReceiverNamesInspection())
     fun `test different receivers names`() = doTest("different_receivers_names.v", VlangReceiverNamesInspection())
 
+    fun `test var names`() = doTest("variables.v", VlangVarNamingConventionInspection())
+
     companion object {
         val FUNCTION = VlangFunctionNamingConventionInspection()
         val CLASS_LIKE = VlangClassLikeNamingConventionInspection()

--- a/src/test/resources/inspections/namingConventions/variables.v
+++ b/src/test/resources/inspections/namingConventions/variables.v
@@ -1,0 +1,4 @@
+module main
+fn main() {
+    <error descr="Variable name cannot contain uppercase letters, use snake_case instead">InvalidVarName</error> := 1
+}


### PR DESCRIPTION
Currently, compiler throw errors if variables is not in snake_case. So here's inspector for it